### PR TITLE
Update wp-taxonomy-import.php

### DIFF
--- a/wp-taxonomy-import.php
+++ b/wp-taxonomy-import.php
@@ -72,6 +72,9 @@ if ( !class_exists( "WPTaxonomyImport" ) ) {
 						if ( is_wp_error( $result ) ) {
 							return die( "$catname produced this -> ".$result->get_error_message() );
 						}
+						else {
+							$parent_id = $result['term_id'];
+						}
 						$created_categories[] = $category_name;
 					}
 


### PR DESCRIPTION
Category A -> Category B -> Category C

とフィールドに入力した場合、Category A や Category B がまだ存在しないと、上記の親子関係が無視されて登録されてしまうようでした。
（Carogory A〜C すべてが親を持たないカテゴリーとして登録されてしまう）

この問題を修正しました。
