### PR TITLE
Update wp-taxonomy-import.php

### DIFF
--- a/wp-taxonomy-import.php
+++ b/wp-taxonomy-import.php
@@ -44,7 +44,7 @@ if ( !class_exists( "WPTaxonomyImport" ) ) {
 					$category = explode( $delimiter, $category );
 					$category_name = $category[0];
 					$category_slug = $category[1];
-					$category_description = ( isset( $category[2] ) ? substr( $category[2], 1, -1 ) : '' );
+					$category_description = ( isset( $category[2] ) ? preg_replace('/"([^"]*)"/', '$1', trim( $category[2] ) ) : '' );
 				}
 				else {
 					$category_name = $category;


### PR DESCRIPTION
Category$slug$description

という形で、カテゴリーの説明文を追加した際、WordPress側に登録される説明文が "" で囲われた状態で登録されるようでしたが、WordPressには "" を除いた形で登録されるよう修正しました。
